### PR TITLE
Model and Stim files for 50% and 25% of Gibg

### DIFF
--- a/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Model_ERK-stimd-CaC1000-Gbg1000-ISO-HFS.xml
+++ b/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Model_ERK-stimd-CaC1000-Gbg1000-ISO-HFS.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<SDRun xmlns:xi="http://www.w3.org/2001/XInclude" xmlns="http://stochdiff.textensor.org">
+    <!-- this file defines a single run of the calculation, using morphology and 
+	 reaction data brought in from other files --> 
+
+          <xi:include href="../Rxn_ERK-d.xml" />
+          <xi:include href="../Morph.xml" />        
+          <xi:include href="../IC_ERK-Test_basald.xml" />
+          <xi:include href="../Out_ERK-Test.xml" />
+	  <xi:include href="Stim_ERK_CaC1000_Gbg1000-ISO-HFS.xml" />
+ 
+ 
+    <!--2D means the morphology is interpreted like a flatworm, 3D for
+	roundworms. The 2D case is good for testing as it is easy to visualize the
+results. depth 2D units are microns  -->
+    <geometry>          2D           </geometry>
+    <depth2D>           0.40          </depth2D>
+    <distribution>      BINOMIAL     </distribution>
+    <algorithm>         INDEPENDENT  </algorithm>
+    <simulationSeed>    123       </simulationSeed>
+
+
+    <!-- run time for the calculation, milliseconds -->
+    <runtime>          1800000      </runtime>
+
+    <!-- set the seed to get the same spines each time testing -->
+    <spineSeed>          123          </spineSeed>
+
+    <discretization>
+	<!-- default largest size for elements in bulk volumes (dendrites), microns -->	
+       <defaultMaxElementSide>8</defaultMaxElementSide> 
+        
+    <!-- surfaceLayers> 0.1 </surfaceLayers -->
+    </discretization>
+
+    <outputInterval>      200.0   </outputInterval>
+
+    <!-- the tolerace is used for adaptive sims -->
+    <tolerance>           0.01       </tolerance>
+    <!-- calculation types include
+	 GRID_STEPPED_STOCHASTIC (old fixedStep tau-leap),
+	 GRID_STEPPED_CONTINUOUS (deterministic), and
+	 GRID_ADAPTIVE (new adaptive (asynchronous tau-leap).-->
+    <calculation>GRID_ADAPTIVE</calculation>
+</SDRun>

--- a/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Model_ERK-stimd-CaC1000-Gbg500-ISO-HFS.xml
+++ b/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Model_ERK-stimd-CaC1000-Gbg500-ISO-HFS.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<SDRun xmlns:xi="http://www.w3.org/2001/XInclude" xmlns="http://stochdiff.textensor.org">
+    <!-- this file defines a single run of the calculation, using morphology and 
+	 reaction data brought in from other files --> 
+
+          <xi:include href="../Rxn_ERK-d.xml" />
+          <xi:include href="../Morph.xml" />        
+          <xi:include href="../IC_ERK-Test_basald.xml" />
+          <xi:include href="../Out_ERK-Test.xml" />
+	  <xi:include href="Stim_ERK_CaC1000_Gbg500-ISO-HFS.xml" />
+ 
+ 
+    <!--2D means the morphology is interpreted like a flatworm, 3D for
+	roundworms. The 2D case is good for testing as it is easy to visualize the
+results. depth 2D units are microns  -->
+    <geometry>          2D           </geometry>
+    <depth2D>           0.40          </depth2D>
+    <distribution>      BINOMIAL     </distribution>
+    <algorithm>         INDEPENDENT  </algorithm>
+    <simulationSeed>    123       </simulationSeed>
+
+
+    <!-- run time for the calculation, milliseconds -->
+    <runtime>          1800000      </runtime>
+
+    <!-- set the seed to get the same spines each time testing -->
+    <spineSeed>          123          </spineSeed>
+
+    <discretization>
+	<!-- default largest size for elements in bulk volumes (dendrites), microns -->	
+       <defaultMaxElementSide>8</defaultMaxElementSide> 
+        
+    <!-- surfaceLayers> 0.1 </surfaceLayers -->
+    </discretization>
+
+    <outputInterval>      200.0   </outputInterval>
+
+    <!-- the tolerace is used for adaptive sims -->
+    <tolerance>           0.01       </tolerance>
+    <!-- calculation types include
+	 GRID_STEPPED_STOCHASTIC (old fixedStep tau-leap),
+	 GRID_STEPPED_CONTINUOUS (deterministic), and
+	 GRID_ADAPTIVE (new adaptive (asynchronous tau-leap).-->
+    <calculation>GRID_ADAPTIVE</calculation>
+</SDRun>

--- a/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Model_ERK-stimd-Gbg1000-ISO-LFS.xml
+++ b/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Model_ERK-stimd-Gbg1000-ISO-LFS.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<SDRun xmlns:xi="http://www.w3.org/2001/XInclude" xmlns="http://stochdiff.textensor.org">
+    <!-- this file defines a single run of the calculation, using morphology and 
+	 reaction data brought in from other files --> 
+
+          <xi:include href="../Rxn_ERK-d.xml" />
+          <xi:include href="../Morph.xml" />        
+          <xi:include href="../IC_ERK-Test_basald.xml" />
+          <xi:include href="../Out_ERK-Test.xml" />
+	  <xi:include href="Stim_ERK_Gbg1000-ISO-LFS.xml" />
+ 
+ 
+    <!--2D means the morphology is interpreted like a flatworm, 3D for
+	roundworms. The 2D case is good for testing as it is easy to visualize the
+results. depth 2D units are microns  -->
+    <geometry>          2D           </geometry>
+    <depth2D>           0.40          </depth2D>
+    <distribution>      BINOMIAL     </distribution>
+    <algorithm>         INDEPENDENT  </algorithm>
+    <simulationSeed>    123       </simulationSeed>
+
+
+    <!-- run time for the calculation, milliseconds -->
+    <runtime>          1800000      </runtime>
+
+    <!-- set the seed to get the same spines each time testing -->
+    <spineSeed>          123          </spineSeed>
+
+    <discretization>
+	<!-- default largest size for elements in bulk volumes (dendrites), microns -->	
+       <defaultMaxElementSide>8</defaultMaxElementSide> 
+        
+    <!-- surfaceLayers> 0.1 </surfaceLayers -->
+    </discretization>
+
+    <outputInterval>      200.0   </outputInterval>
+
+    <!-- the tolerace is used for adaptive sims -->
+    <tolerance>           0.01       </tolerance>
+    <!-- calculation types include
+	 GRID_STEPPED_STOCHASTIC (old fixedStep tau-leap),
+	 GRID_STEPPED_CONTINUOUS (deterministic), and
+	 GRID_ADAPTIVE (new adaptive (asynchronous tau-leap).-->
+    <calculation>GRID_ADAPTIVE</calculation>
+</SDRun>

--- a/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Model_ERK-stimd-Gbg250-ISO.xml
+++ b/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Model_ERK-stimd-Gbg250-ISO.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<SDRun xmlns:xi="http://www.w3.org/2001/XInclude" xmlns="http://stochdiff.textensor.org">
+    <!-- this file defines a single run of the calculation, using morphology and 
+	 reaction data brought in from other files --> 
+
+          <xi:include href="../Rxn_ERK-d.xml" />
+          <xi:include href="../Morph.xml" />        
+          <xi:include href="../IC_ERK-Test_basald.xml" />
+          <xi:include href="../Out_ERK-Test.xml" />
+	  <xi:include href="Stim_ERK_Gbg250-ISO.xml" />
+ 
+ 
+    <!--2D means the morphology is interpreted like a flatworm, 3D for
+	roundworms. The 2D case is good for testing as it is easy to visualize the
+results. depth 2D units are microns  -->
+    <geometry>          2D           </geometry>
+    <depth2D>           0.40          </depth2D>
+    <distribution>      BINOMIAL     </distribution>
+    <algorithm>         INDEPENDENT  </algorithm>
+    <simulationSeed>    123       </simulationSeed>
+
+
+    <!-- run time for the calculation, milliseconds -->
+    <runtime>          1800000      </runtime>
+
+    <!-- set the seed to get the same spines each time testing -->
+    <spineSeed>          123          </spineSeed>
+
+    <discretization>
+	<!-- default largest size for elements in bulk volumes (dendrites), microns -->	
+       <defaultMaxElementSide>8</defaultMaxElementSide> 
+        
+    <!-- surfaceLayers> 0.1 </surfaceLayers -->
+    </discretization>
+
+    <outputInterval>      200.0   </outputInterval>
+
+    <!-- the tolerace is used for adaptive sims -->
+    <tolerance>           0.01       </tolerance>
+    <!-- calculation types include
+	 GRID_STEPPED_STOCHASTIC (old fixedStep tau-leap),
+	 GRID_STEPPED_CONTINUOUS (deterministic), and
+	 GRID_ADAPTIVE (new adaptive (asynchronous tau-leap).-->
+    <calculation>GRID_ADAPTIVE</calculation>
+</SDRun>

--- a/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Model_ERK-stimd-Gbg500-ISO-LFS.xml
+++ b/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Model_ERK-stimd-Gbg500-ISO-LFS.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<SDRun xmlns:xi="http://www.w3.org/2001/XInclude" xmlns="http://stochdiff.textensor.org">
+    <!-- this file defines a single run of the calculation, using morphology and 
+	 reaction data brought in from other files --> 
+
+          <xi:include href="../Rxn_ERK-d.xml" />
+          <xi:include href="../Morph.xml" />        
+          <xi:include href="../IC_ERK-Test_basald.xml" />
+          <xi:include href="../Out_ERK-Test.xml" />
+	  <xi:include href="Stim_ERK_Gbg500-ISO-LFS.xml" />
+ 
+ 
+    <!--2D means the morphology is interpreted like a flatworm, 3D for
+	roundworms. The 2D case is good for testing as it is easy to visualize the
+results. depth 2D units are microns  -->
+    <geometry>          2D           </geometry>
+    <depth2D>           0.40          </depth2D>
+    <distribution>      BINOMIAL     </distribution>
+    <algorithm>         INDEPENDENT  </algorithm>
+    <simulationSeed>    123       </simulationSeed>
+
+
+    <!-- run time for the calculation, milliseconds -->
+    <runtime>          1800000      </runtime>
+
+    <!-- set the seed to get the same spines each time testing -->
+    <spineSeed>          123          </spineSeed>
+
+    <discretization>
+	<!-- default largest size for elements in bulk volumes (dendrites), microns -->	
+       <defaultMaxElementSide>8</defaultMaxElementSide> 
+        
+    <!-- surfaceLayers> 0.1 </surfaceLayers -->
+    </discretization>
+
+    <outputInterval>      200.0   </outputInterval>
+
+    <!-- the tolerace is used for adaptive sims -->
+    <tolerance>           0.01       </tolerance>
+    <!-- calculation types include
+	 GRID_STEPPED_STOCHASTIC (old fixedStep tau-leap),
+	 GRID_STEPPED_CONTINUOUS (deterministic), and
+	 GRID_ADAPTIVE (new adaptive (asynchronous tau-leap).-->
+    <calculation>GRID_ADAPTIVE</calculation>
+</SDRun>

--- a/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Model_ERK-stimd-Gbg500-ISO.xml
+++ b/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Model_ERK-stimd-Gbg500-ISO.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<SDRun xmlns:xi="http://www.w3.org/2001/XInclude" xmlns="http://stochdiff.textensor.org">
+    <!-- this file defines a single run of the calculation, using morphology and 
+	 reaction data brought in from other files --> 
+
+          <xi:include href="../Rxn_ERK-d.xml" />
+          <xi:include href="../Morph.xml" />        
+          <xi:include href="../IC_ERK-Test_basald.xml" />
+          <xi:include href="../Out_ERK-Test.xml" />
+	  <xi:include href="Stim_ERK_Gbg500-ISO.xml" />
+ 
+ 
+    <!--2D means the morphology is interpreted like a flatworm, 3D for
+	roundworms. The 2D case is good for testing as it is easy to visualize the
+results. depth 2D units are microns  -->
+    <geometry>          2D           </geometry>
+    <depth2D>           0.40          </depth2D>
+    <distribution>      BINOMIAL     </distribution>
+    <algorithm>         INDEPENDENT  </algorithm>
+    <simulationSeed>    123       </simulationSeed>
+
+
+    <!-- run time for the calculation, milliseconds -->
+    <runtime>          1800000      </runtime>
+
+    <!-- set the seed to get the same spines each time testing -->
+    <spineSeed>          123          </spineSeed>
+
+    <discretization>
+	<!-- default largest size for elements in bulk volumes (dendrites), microns -->	
+       <defaultMaxElementSide>8</defaultMaxElementSide> 
+        
+    <!-- surfaceLayers> 0.1 </surfaceLayers -->
+    </discretization>
+
+    <outputInterval>      200.0   </outputInterval>
+
+    <!-- the tolerace is used for adaptive sims -->
+    <tolerance>           0.01       </tolerance>
+    <!-- calculation types include
+	 GRID_STEPPED_STOCHASTIC (old fixedStep tau-leap),
+	 GRID_STEPPED_CONTINUOUS (deterministic), and
+	 GRID_ADAPTIVE (new adaptive (asynchronous tau-leap).-->
+    <calculation>GRID_ADAPTIVE</calculation>
+</SDRun>

--- a/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Stim_ERK_CaC1000_Gbg1000-ISO-HFS.xml
+++ b/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Stim_ERK_CaC1000_Gbg1000-ISO-HFS.xml
@@ -1,0 +1,119 @@
+
+<StimulationSet>
+
+  <!--onset and duration in ms, rate in particles/ms-->
+
+      
+
+ <!--cAMP -->
+ <InjectionStim specieID="cAMP" injectionSite="pointA">
+        <onset>               101020          </onset>
+        <duration>       10        </duration> 
+       	<rate>              1       </rate>
+	<period>        40             </period>
+	<end>         402000           </end>
+</InjectionStim>
+ 
+
+<!--fast injection to have sharp increase-->
+<InjectionStim specieID="cAMP" injectionSite="pointA">
+  <onset>               401000          </onset>
+        <duration>        10         </duration> 
+       	<rate>               3000      </rate>
+   
+   	<period>        1100             </period>
+	<end>          402000           </end>
+	
+</InjectionStim>
+
+ <!--cAMP -->
+ <InjectionStim specieID="cAMP" injectionSite="pointA">
+        <onset>               101020          </onset>
+        <duration>       5        </duration> 
+       	<rate>              1       </rate>
+	<period>        40             </period>
+	<end>         602000           </end>
+ </InjectionStim>
+ 
+<!--maintained desire concentration-->
+
+ <InjectionStim specieID="cAMP" injectionSite="pointA">
+        <onset>               401020          </onset>
+        <duration>       1        </duration> 
+       	<rate>              40       </rate>
+	<period>        40             </period>
+	<end>          410000           </end>
+</InjectionStim>
+
+
+
+    <!--Ca -->
+
+ 
+<!--fast injection to have sharp increase-->
+<InjectionStim specieID="Ca" injectionSite="pointA">
+  
+        <onset>               401000          </onset>
+        <duration>        10         </duration> 
+        <rate>             216000.0       </rate>
+   
+	<period>        1100             </period>
+	<end>          402000           </end>
+</InjectionStim>
+
+<!--maintained desire concentration-->
+<InjectionStim specieID="Ca" injectionSite="pointA">
+  
+        <onset>               401020          </onset>
+        <duration>        10         </duration> 
+        <rate>            24000       </rate>
+	<period>        320         </period>
+	<end>        402000        </end>
+</InjectionStim>
+
+<!--buff to bring back Ca to basal. repeated -->
+<InjectionStim specieID="Cbuff" injectionSite="pointA">
+
+        <onset>               402000          </onset>
+        <duration>        5         </duration> 
+      	<rate>       200000 </rate>
+	<period>        1000             </period>
+	<end>          404000           </end>
+</InjectionStim>
+
+
+
+<!--slow buff for external Ca, keep basal -->   
+   <InjectionStim specieID="Cbuffslow" injectionSite="pointA">
+
+        <onset>               401000          </onset>
+        <duration>        250        </duration> 
+	<rate>   1200           </rate>
+	<period>        1100             </period>
+	<end>          403000           </end>
+   </InjectionStim>
+
+ <!--Gbg -->
+
+
+
+<InjectionStim specieID="Gbg" injectionSite="pointA">
+        <onset>               250000         </onset>
+        <duration>            200000       </duration> 
+        <rate>               0.1        </rate>
+	<end>          1800000           </end>
+</InjectionStim>
+
+
+
+<!-- <InjectionStim specieID="Gbuff" injectionSite="pointA">
+        <onset>               302000          </onset>
+        <duration>            5         </duration> 
+        <rate>                602      </rate>
+	<period>        11100             </period>
+	<end>          303000           </end>
+ </InjectionStim>
+
+-->
+  
+</StimulationSet>

--- a/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Stim_ERK_CaC1000_Gbg500-ISO-HFS.xml
+++ b/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Stim_ERK_CaC1000_Gbg500-ISO-HFS.xml
@@ -1,0 +1,119 @@
+
+<StimulationSet>
+
+  <!--onset and duration in ms, rate in particles/ms-->
+
+      
+
+ <!--cAMP -->
+ <InjectionStim specieID="cAMP" injectionSite="pointA">
+        <onset>               101020          </onset>
+        <duration>       10        </duration> 
+       	<rate>              1       </rate>
+	<period>        40             </period>
+	<end>         402000           </end>
+</InjectionStim>
+ 
+
+<!--fast injection to have sharp increase-->
+<InjectionStim specieID="cAMP" injectionSite="pointA">
+  <onset>               401000          </onset>
+        <duration>        10         </duration> 
+       	<rate>               3000      </rate>
+   
+   	<period>        1100             </period>
+	<end>          402000           </end>
+	
+</InjectionStim>
+
+ <!--cAMP -->
+ <InjectionStim specieID="cAMP" injectionSite="pointA">
+        <onset>               101020          </onset>
+        <duration>       5        </duration> 
+       	<rate>              1       </rate>
+	<period>        40             </period>
+	<end>         602000           </end>
+ </InjectionStim>
+ 
+<!--maintained desire concentration-->
+
+ <InjectionStim specieID="cAMP" injectionSite="pointA">
+        <onset>               401020          </onset>
+        <duration>       1        </duration> 
+       	<rate>              40       </rate>
+	<period>        40             </period>
+	<end>          410000           </end>
+</InjectionStim>
+
+
+
+    <!--Ca -->
+
+ 
+<!--fast injection to have sharp increase-->
+<InjectionStim specieID="Ca" injectionSite="pointA">
+  
+        <onset>               401000          </onset>
+        <duration>        10         </duration> 
+        <rate>             216000.0       </rate>
+   
+	<period>        1100             </period>
+	<end>          402000           </end>
+</InjectionStim>
+
+<!--maintained desire concentration-->
+<InjectionStim specieID="Ca" injectionSite="pointA">
+  
+        <onset>               401020          </onset>
+        <duration>        10         </duration> 
+        <rate>            24000       </rate>
+	<period>        320         </period>
+	<end>        402000        </end>
+</InjectionStim>
+
+<!--buff to bring back Ca to basal. repeated -->
+<InjectionStim specieID="Cbuff" injectionSite="pointA">
+
+        <onset>               402000          </onset>
+        <duration>        5         </duration> 
+      	<rate>       200000 </rate>
+	<period>        1000             </period>
+	<end>          404000           </end>
+</InjectionStim>
+
+
+
+<!--slow buff for external Ca, keep basal -->   
+   <InjectionStim specieID="Cbuffslow" injectionSite="pointA">
+
+        <onset>               401000          </onset>
+        <duration>        250        </duration> 
+	<rate>   1200           </rate>
+	<period>        1100             </period>
+	<end>          403000           </end>
+   </InjectionStim>
+
+ <!--Gbg -->
+
+
+
+<InjectionStim specieID="Gbg" injectionSite="pointA">
+        <onset>               250000         </onset>
+        <duration>            200000       </duration> 
+        <rate>               0.05        </rate>
+	<end>          1800000           </end>
+</InjectionStim>
+
+
+
+<!-- <InjectionStim specieID="Gbuff" injectionSite="pointA">
+        <onset>               302000          </onset>
+        <duration>            5         </duration> 
+        <rate>                602      </rate>
+	<period>        11100             </period>
+	<end>          303000           </end>
+ </InjectionStim>
+
+-->
+  
+</StimulationSet>

--- a/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Stim_ERK_Gbg1000-ISO-LFS.xml
+++ b/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Stim_ERK_Gbg1000-ISO-LFS.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StimulationSet>
+
+    <!-- the injectionSite must match a regionLabel deefined in the morphology -->
+   
+
+<!-- Train I -->
+
+
+
+<!-- Train I -->
+
+<!-- Train I -->
+<InjectionStim specieID="cAMP" injectionSite="pointA">
+        <onset>               101020          </onset>
+        <duration>       10        </duration> 
+       	<rate>              1       </rate>
+	<period>        40             </period>
+	<end>         402000           </end>
+</InjectionStim>
+ <!--fast injection to have sharp increase-->
+<InjectionStim specieID="cAMP" injectionSite="pointA">
+  <onset>               401000          </onset>
+        <duration>        10         </duration> 
+       	<rate>               750      </rate>
+   
+   	<period>        1100             </period>
+	<end>          682000           </end>
+	
+</InjectionStim>
+<InjectionStim specieID="Ca" injectionSite="pointA">
+        <onset>400000</onset>
+	<duration>3</duration>
+	<rate>200</rate>
+        <period>200</period>
+        <end>580000</end> 
+       
+</InjectionStim>
+
+<InjectionStim specieID="Gbg" injectionSite="pointA">
+        <onset>               300000         </onset>
+        <duration>            150000       </duration> 
+        <rate>               0.1        </rate>
+	<end>          1800000           </end>
+</InjectionStim>
+</StimulationSet>

--- a/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Stim_ERK_Gbg250-ISO.xml
+++ b/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Stim_ERK_Gbg250-ISO.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StimulationSet>
+
+    <!-- the injectionSite must match a regionLabel deefined in the morphology -->
+   
+
+<!-- Train I -->
+
+
+
+<!-- Train I -->
+
+<!-- Train I -->
+<InjectionStim specieID="cAMP" injectionSite="pointA">
+        <onset>               101020          </onset>
+        <duration>       10        </duration> 
+       	<rate>              3.5       </rate>
+	<period>        40             </period>
+	<end>         402000           </end>
+</InjectionStim>
+<InjectionStim specieID="cAMP" injectionSite="pointA">
+        <onset>               401020          </onset>
+        <duration>       10        </duration> 
+       	<rate>              1       </rate>
+	<period>        40             </period>
+	<end>         702000           </end>
+</InjectionStim>
+
+<InjectionStim specieID="Gbg" injectionSite="pointA">
+        <onset>               300000         </onset>
+        <duration>            150000       </duration> 
+        <rate>               0.025       </rate>
+	<end>          1800000           </end>
+</InjectionStim>
+</StimulationSet>

--- a/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Stim_ERK_Gbg500-ISO-LFS.xml
+++ b/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Stim_ERK_Gbg500-ISO-LFS.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StimulationSet>
+
+    <!-- the injectionSite must match a regionLabel deefined in the morphology -->
+   
+
+<!-- Train I -->
+
+
+
+<!-- Train I -->
+
+<!-- Train I -->
+<InjectionStim specieID="cAMP" injectionSite="pointA">
+        <onset>               101020          </onset>
+        <duration>       10        </duration> 
+       	<rate>              1       </rate>
+	<period>        40             </period>
+	<end>         402000           </end>
+</InjectionStim>
+ <!--fast injection to have sharp increase-->
+<InjectionStim specieID="cAMP" injectionSite="pointA">
+  <onset>               401000          </onset>
+        <duration>        10         </duration> 
+       	<rate>               750      </rate>
+   
+   	<period>        1100             </period>
+	<end>          682000           </end>
+	
+</InjectionStim>
+<InjectionStim specieID="Ca" injectionSite="pointA">
+        <onset>400000</onset>
+	<duration>3</duration>
+	<rate>200</rate>
+        <period>200</period>
+        <end>580000</end> 
+       
+</InjectionStim>
+
+<InjectionStim specieID="Gbg" injectionSite="pointA">
+        <onset>               300000         </onset>
+        <duration>            150000       </duration> 
+        <rate>               0.05        </rate>
+	<end>          1800000           </end>
+</InjectionStim>
+</StimulationSet>

--- a/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Stim_ERK_Gbg500-ISO.xml
+++ b/Experiment/simulation/5_LTP_paradigms/all_pathways/Stim/Stim_ERK_Gbg500-ISO.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StimulationSet>
+
+    <!-- the injectionSite must match a regionLabel deefined in the morphology -->
+   
+
+<!-- Train I -->
+
+
+
+<!-- Train I -->
+
+<!-- Train I -->
+<InjectionStim specieID="cAMP" injectionSite="pointA">
+        <onset>               101020          </onset>
+        <duration>       10        </duration> 
+       	<rate>              3.5       </rate>
+	<period>        40             </period>
+	<end>         402000           </end>
+</InjectionStim>
+<InjectionStim specieID="cAMP" injectionSite="pointA">
+        <onset>               401020          </onset>
+        <duration>       10        </duration> 
+       	<rate>              1       </rate>
+	<period>        40             </period>
+	<end>         702000           </end>
+</InjectionStim>
+
+<InjectionStim specieID="Gbg" injectionSite="pointA">
+        <onset>               300000         </onset>
+        <duration>            150000       </duration> 
+        <rate>               0.05        </rate>
+	<end>          1800000           </end>
+</InjectionStim>
+</StimulationSet>


### PR DESCRIPTION
Additional stimulation and model files for ISO, ISO+HFS, ISO+LFS paradigms with 50% and 25% Gibg recruitment in the spine.